### PR TITLE
8.3: import json c 0.14 11.el9.src.rpm

### DIFF
--- a/SOURCES/json-c-0.14-20200419.tar.gz
+++ b/SOURCES/json-c-0.14-20200419.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec4eb70e0f6c0d707b9b1ec646cf7c860f4abb3562a90ea6e4d78d177fd95303
+size 306247

--- a/SOURCES/json-c-0.14-arraylist_optimizations.patch
+++ b/SOURCES/json-c-0.14-arraylist_optimizations.patch
@@ -1,0 +1,80 @@
+From 4a546e7b2f471157c6f479df1ef687864fcbd89e Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Sun, 24 May 2020 03:53:32 +0000
+Subject: [PATCH] In arraylist, use malloc instead of calloc, avoid clearing
+ with memeset until we really need to, and micro-optimize array_list_add().
+
+---
+ arraylist.c | 29 +++++++++++++++++++++++++----
+ 1 file changed, 25 insertions(+), 4 deletions(-)
+
+diff --git a/arraylist.c b/arraylist.c
+index e5524aca75..3e7bfa8950 100644
+--- a/arraylist.c
++++ b/arraylist.c
+@@ -40,13 +40,13 @@ struct array_list *array_list_new(array_list_free_fn *free_fn)
+ {
+ 	struct array_list *arr;
+ 
+-	arr = (struct array_list *)calloc(1, sizeof(struct array_list));
++	arr = (struct array_list *)malloc(sizeof(struct array_list));
+ 	if (!arr)
+ 		return NULL;
+ 	arr->size = ARRAY_LIST_DEFAULT_SIZE;
+ 	arr->length = 0;
+ 	arr->free_fn = free_fn;
+-	if (!(arr->array = (void **)calloc(arr->size, sizeof(void *))))
++	if (!(arr->array = (void **)malloc(arr->size * sizeof(void *))))
+ 	{
+ 		free(arr);
+ 		return NULL;
+@@ -92,11 +92,11 @@ static int array_list_expand_internal(struct array_list *arr, size_t max)
+ 	if (!(t = realloc(arr->array, new_size * sizeof(void *))))
+ 		return -1;
+ 	arr->array = (void **)t;
+-	(void)memset(arr->array + arr->size, 0, (new_size - arr->size) * sizeof(void *));
+ 	arr->size = new_size;
+ 	return 0;
+ }
+ 
++//static inline int _array_list_put_idx(struct array_list *arr, size_t idx, void *data)
+ int array_list_put_idx(struct array_list *arr, size_t idx, void *data)
+ {
+ 	if (idx > SIZE_T_MAX - 1)
+@@ -106,6 +106,17 @@ int array_list_put_idx(struct array_list *arr, size_t idx, void *data)
+ 	if (idx < arr->length && arr->array[idx])
+ 		arr->free_fn(arr->array[idx]);
+ 	arr->array[idx] = data;
++	if (idx > arr->length)
++	{
++		/* Zero out the arraylist slots in between the old length
++		   and the newly added entry so we know those entries are
++		   empty.
++		   e.g. when setting array[7] in an array that used to be 
++		   only 5 elements longs, array[5] and array[6] need to be
++		   set to 0.
++		 */
++		memset(arr->array + arr->length, 0, (idx - arr->length) * sizeof(void *));
++	}
+ 	if (arr->length <= idx)
+ 		arr->length = idx + 1;
+ 	return 0;
+@@ -113,7 +124,17 @@ int array_list_put_idx(struct array_list *arr, size_t idx, void *data)
+ 
+ int array_list_add(struct array_list *arr, void *data)
+ {
+-	return array_list_put_idx(arr, arr->length, data);
++	/* Repeat some of array_list_put_idx() so we can skip several
++	   checks that we know are unnecessary when appending at the end
++	 */
++	size_t idx = arr->length;
++	if (idx > SIZE_T_MAX - 1)
++		return -1;
++	if (array_list_expand_internal(arr, idx + 1))
++		return -1;
++	arr->array[idx] = data;
++	arr->length++;
++	return 0;
+ }
+ 
+ void array_list_sort(struct array_list *arr, int (*compar)(const void *, const void *))

--- a/SOURCES/json-c-0.14-backport_fixes_from_master.patch
+++ b/SOURCES/json-c-0.14-backport_fixes_from_master.patch
@@ -1,0 +1,874 @@
+From 812d5e3903c5507c9d015cf0078b3a63d391b022 Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Tue, 21 Apr 2020 03:19:17 +0000
+Subject: [PATCH 01/18] Issue #471: always create directories with mode 0755,
+ regardless of umask.
+
+---
+ CMakeLists.txt | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c51f477c5f..ea536947df 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -392,6 +392,17 @@ target_include_directories(${PROJECT_NAME}
+         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+ )
+ 
++# Always create new install dirs with 0755 permissions, regardless of umask
++set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
++	OWNER_READ
++	OWNER_WRITE
++	OWNER_EXECUTE
++	GROUP_READ
++	GROUP_EXECUTE
++	WORLD_READ
++	WORLD_EXECUTE
++   )
++
+ install(TARGETS ${PROJECT_NAME}
+     EXPORT ${PROJECT_NAME}-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+
+From 3a3ab6c7d8991892a44267919204f852dbd512ed Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Sun, 3 May 2020 03:50:16 +0000
+Subject: [PATCH 02/18] Fix cmake-configure to accept "--prefix=<foo>" in
+ addition to "--prefix <foo>" (see also Issue #591)
+
+---
+ cmake-configure | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/cmake-configure b/cmake-configure
+index 7a06b660c1..2fcc39e3ca 100755
+--- a/cmake-configure
++++ b/cmake-configure
+@@ -52,6 +52,9 @@ while [ $# -gt 0 ] ; do
+ 		FLAGS+=(-DCMAKE_INSTALL_PREFIX="$2")
+ 		shift
+ 		;;
++	--prefix=*)
++		FLAGS+=(-DCMAKE_INSTALL_PREFIX="${1##--prefix=}")
++		;;
+ 	--enable-threading)
+ 		FLAGS+=(-DENABLE_THREADING=ON)
+ 		;;
+
+From 0ca0361a24cd9f76b9bcb92eba2a752ff5269cea Mon Sep 17 00:00:00 2001
+From: Tudor Brindus <me@tbrindus.ca>
+Date: Fri, 1 May 2020 22:24:20 -0400
+Subject: [PATCH 03/18] Fix segmentation fault in CPUID check
+
+---
+ random_seed.c | 15 ++-------------
+ 1 file changed, 2 insertions(+), 13 deletions(-)
+
+diff --git a/random_seed.c b/random_seed.c
+index fc19e26d13..c459f0f92f 100644
+--- a/random_seed.c
++++ b/random_seed.c
+@@ -26,19 +26,8 @@
+ static void do_cpuid(int regs[], int h)
+ {
+ 	/* clang-format off */
+-    __asm__ __volatile__(
+-#if defined __x86_64__
+-                         "pushq %%rbx;\n"
+-#else
+-                         "pushl %%ebx;\n"
+-#endif
+-                         "cpuid;\n"
+-#if defined __x86_64__
+-                         "popq %%rbx;\n"
+-#else
+-                         "popl %%ebx;\n"
+-#endif
+-                         : "=a"(regs[0]), [ebx] "=r"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
++    __asm__ __volatile__("cpuid"
++                         : "=a"(regs[0]), "=b"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
+                          : "a"(h));
+ 	/* clang-format on */
+ }
+
+From 23005a7d9d7e9a1c433689b5df29a53bf629b470 Mon Sep 17 00:00:00 2001
+From: Tudor Brindus <me@tbrindus.ca>
+Date: Fri, 1 May 2020 21:09:22 -0400
+Subject: [PATCH 04/18] Detect broken RDRAND during initialization
+
+Some CPUs advertise RDRAND in CPUID, but return 0xFFFFFFFF
+unconditionally. To avoid locking up later, test RDRAND during
+initialization, and if it returns 0xFFFFFFFF, mark it as nonexistent.
+
+Fixes #588.
+---
+ random_seed.c | 37 +++++++++++++++++++++++++++++++++----
+ 1 file changed, 33 insertions(+), 4 deletions(-)
+
+diff --git a/random_seed.c b/random_seed.c
+index c459f0f92f..4ddcb07d16 100644
+--- a/random_seed.c
++++ b/random_seed.c
+@@ -43,12 +43,41 @@ static void do_cpuid(int regs[], int h)
+ 
+ #if HAS_X86_CPUID
+ 
++static int get_rdrand_seed(void);
++
++// Valid values are -1 (haven't tested), 0 (no), and 1 (yes).
++static int _has_rdrand = -1;
++
+ static int has_rdrand(void)
+ {
+-	// CPUID.01H:ECX.RDRAND[bit 30] == 1
+-	int regs[4];
+-	do_cpuid(regs, 1);
+-	return (regs[2] & (1 << 30)) != 0;
++	if (_has_rdrand == -1)
++	{
++		// CPUID.01H:ECX.RDRAND[bit 30] == 1
++		int regs[4];
++		do_cpuid(regs, 1);
++		if (!(regs[2] & (1 << 30)))
++		{
++			_has_rdrand = 0;
++		} else
++		{
++			// Some CPUs advertise RDRAND in CPUID, but return 0xFFFFFFFF
++			// unconditionally. To avoid locking up later, test RDRAND here. If over
++			// 10 trials RDRAND has returned the same value, declare it broken.
++			_has_rdrand = 0;
++			int prev = get_rdrand_seed();
++			for (int i = 0; i < 10; i++) {
++				int temp = get_rdrand_seed();
++				if (temp != prev) {
++					_has_rdrand = 1;
++					break;
++				}
++
++				prev = temp;
++			}
++		}
++	}
++
++	return _has_rdrand;
+ }
+ 
+ #endif
+
+From 8d28e677e6a0919dcea40ea9a5b5d484df1d7d41 Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Mon, 4 May 2020 01:29:02 +0000
+Subject: [PATCH 05/18] Issue #589: drop the rdrand test loops to just 3, tweak
+ comments and add some links to bug reports, and decrease the nesting level of
+ the has_rdrand() function.
+
+---
+ random_seed.c | 64 +++++++++++++++++++++++++++++++--------------------
+ 1 file changed, 39 insertions(+), 25 deletions(-)
+
+diff --git a/random_seed.c b/random_seed.c
+index 4ddcb07d16..b5f8a0795e 100644
+--- a/random_seed.c
++++ b/random_seed.c
+@@ -45,36 +45,46 @@ static void do_cpuid(int regs[], int h)
+ 
+ static int get_rdrand_seed(void);
+ 
+-// Valid values are -1 (haven't tested), 0 (no), and 1 (yes).
++/* Valid values are -1 (haven't tested), 0 (no), and 1 (yes). */
+ static int _has_rdrand = -1;
+ 
+ static int has_rdrand(void)
+ {
+-	if (_has_rdrand == -1)
++	if (_has_rdrand != -1)
+ 	{
+-		// CPUID.01H:ECX.RDRAND[bit 30] == 1
+-		int regs[4];
+-		do_cpuid(regs, 1);
+-		if (!(regs[2] & (1 << 30)))
+-		{
+-			_has_rdrand = 0;
+-		} else
++		return _has_rdrand;
++	}
++
++	/* CPUID.01H:ECX.RDRAND[bit 30] == 1 */
++	int regs[4];
++	do_cpuid(regs, 1);
++	if (!(regs[2] & (1 << 30)))
++	{
++		_has_rdrand = 0;
++		return 0;
++	}
++
++	/*
++	 * Some CPUs advertise RDRAND in CPUID, but return 0xFFFFFFFF
++	 * unconditionally. To avoid locking up later, test RDRAND here. If over
++	 * 3 trials RDRAND has returned the same value, declare it broken.
++	 * Example CPUs are AMD Ryzen 3000 series
++	 * and much older AMD APUs, such as the E1-1500
++	 * https://github.com/systemd/systemd/issues/11810
++	 * https://linuxreviews.org/RDRAND_stops_returning_random_values_on_older_AMD_CPUs_after_suspend
++	 */
++	_has_rdrand = 0;
++	int prev = get_rdrand_seed();
++	for (int i = 0; i < 3; i++)
++	{
++		int temp = get_rdrand_seed();
++		if (temp != prev)
+ 		{
+-			// Some CPUs advertise RDRAND in CPUID, but return 0xFFFFFFFF
+-			// unconditionally. To avoid locking up later, test RDRAND here. If over
+-			// 10 trials RDRAND has returned the same value, declare it broken.
+-			_has_rdrand = 0;
+-			int prev = get_rdrand_seed();
+-			for (int i = 0; i < 10; i++) {
+-				int temp = get_rdrand_seed();
+-				if (temp != prev) {
+-					_has_rdrand = 1;
+-					break;
+-				}
+-
+-				prev = temp;
+-			}
++			_has_rdrand = 1;
++			break;
+ 		}
++
++		prev = temp;
+ 	}
+ 
+ 	return _has_rdrand;
+@@ -92,7 +102,7 @@ static int get_rdrand_seed(void)
+ {
+ 	DEBUG_SEED("get_rdrand_seed");
+ 	int _eax;
+-	// rdrand eax
++	/* rdrand eax */
+ 	/* clang-format off */
+ 	__asm__ __volatile__("1: .byte 0x0F\n"
+ 	                     "   .byte 0xC7\n"
+@@ -132,7 +142,7 @@ static int get_rdrand_seed(void)
+ 	DEBUG_SEED("get_rdrand_seed");
+ 	int _eax;
+ retry:
+-	// rdrand eax
++	/* rdrand eax */
+ 	__asm _emit 0x0F __asm _emit 0xC7 __asm _emit 0xF0
+ 	__asm jnc retry
+ 	__asm mov _eax, eax
+@@ -206,6 +216,10 @@ static int get_dev_random_seed(void)
+ 
+ /* clang-format off */
+ #include <windows.h>
++
++/* Caution: these blank lines must remain so clang-format doesn't reorder
++   includes to put windows.h after wincrypt.h */
++
+ #include <wincrypt.h>
+ /* clang-format on */
+ #ifndef __GNUC__
+
+From a9695f34c3f4bbd4475597cce1e5d48284286634 Mon Sep 17 00:00:00 2001
+From: Tobias Stoeckmann <tobias@stoeckmann.org>
+Date: Mon, 4 May 2020 19:41:16 +0200
+Subject: [PATCH 06/18] Protect array_list_del_idx against size_t overflow.
+
+If the assignment of stop overflows due to idx and count being
+larger than SIZE_T_MAX in sum, out of boundary access could happen.
+
+It takes invalid usage of this function for this to happen, but
+I decided to add this check so array_list_del_idx is as safe against
+bad usage as the other arraylist functions.
+---
+ arraylist.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arraylist.c b/arraylist.c
+index 12ad8af6d3..e5524aca75 100644
+--- a/arraylist.c
++++ b/arraylist.c
+@@ -136,6 +136,9 @@ int array_list_del_idx(struct array_list *arr, size_t idx, size_t count)
+ {
+ 	size_t i, stop;
+ 
++	/* Avoid overflow in calculation with large indices. */
++	if (idx > SIZE_T_MAX - count)
++		return -1;
+ 	stop = idx + count;
+ 	if (idx >= arr->length || stop > arr->length)
+ 		return -1;
+
+From e66f7f7223fc6a2d3b808216ae28c7de65a54fe7 Mon Sep 17 00:00:00 2001
+From: Tobias Stoeckmann <tobias@stoeckmann.org>
+Date: Mon, 4 May 2020 19:46:45 +0200
+Subject: [PATCH 07/18] Prevent division by zero in linkhash.
+
+If a linkhash with a size of zero is created, then modulo operations
+are prone to division by zero operations.
+
+Purely protective measure against bad usage.
+---
+ linkhash.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/linkhash.c b/linkhash.c
+index 7ea58c0abf..f05cc38030 100644
+--- a/linkhash.c
++++ b/linkhash.c
+@@ -12,6 +12,7 @@
+ 
+ #include "config.h"
+ 
++#include <assert.h>
+ #include <limits.h>
+ #include <stdarg.h>
+ #include <stddef.h>
+@@ -499,6 +500,8 @@ struct lh_table *lh_table_new(int size, lh_entry_free_fn *free_fn, lh_hash_fn *h
+ 	int i;
+ 	struct lh_table *t;
+ 
++	/* Allocate space for elements to avoid divisions by zero. */
++	assert(size > 0);
+ 	t = (struct lh_table *)calloc(1, sizeof(struct lh_table));
+ 	if (!t)
+ 		return NULL;
+
+From c4eae053d4d5c6f300984677b4435f0c00f706a9 Mon Sep 17 00:00:00 2001
+From: Tobias Stoeckmann <tobias@stoeckmann.org>
+Date: Mon, 4 May 2020 19:47:25 +0200
+Subject: [PATCH 08/18] Fix integer overflows.
+
+The data structures linkhash and printbuf are limited to 2 GB in size
+due to a signed integer being used to track their current size.
+
+If too much data is added, then size variable can overflow, which is
+an undefined behaviour in C programming language.
+
+Assuming that a signed int overflow just leads to a negative value,
+like it happens on many sytems (Linux i686/amd64 with gcc), then
+printbuf is vulnerable to an out of boundary write on 64 bit systems.
+---
+ linkhash.c |  7 +++++--
+ printbuf.c | 19 ++++++++++++++++---
+ 2 files changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/linkhash.c b/linkhash.c
+index f05cc38030..51e90b13a2 100644
+--- a/linkhash.c
++++ b/linkhash.c
+@@ -580,9 +580,12 @@ int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v, con
+ {
+ 	unsigned long n;
+ 
+-	if (t->count >= t->size * LH_LOAD_FACTOR)
+-		if (lh_table_resize(t, t->size * 2) != 0)
++	if (t->count >= t->size * LH_LOAD_FACTOR) {
++		/* Avoid signed integer overflow with large tables. */
++		int new_size = INT_MAX / 2 < t->size ? t->size * 2 : INT_MAX;
++		if (t->size == INT_MAX || lh_table_resize(t, new_size) != 0)
+ 			return -1;
++	}
+ 
+ 	n = h % t->size;
+ 
+diff --git a/printbuf.c b/printbuf.c
+index 976c12dde5..00822fac4f 100644
+--- a/printbuf.c
++++ b/printbuf.c
+@@ -15,6 +15,7 @@
+ 
+ #include "config.h"
+ 
++#include <limits.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -65,10 +66,16 @@ static int printbuf_extend(struct printbuf *p, int min_size)
+ 
+ 	if (p->size >= min_size)
+ 		return 0;
+-
+-	new_size = p->size * 2;
+-	if (new_size < min_size + 8)
++	/* Prevent signed integer overflows with large buffers. */
++	if (min_size > INT_MAX - 8)
++		return -1;
++	if (p->size > INT_MAX / 2)
+ 		new_size = min_size + 8;
++	else {
++		new_size = p->size * 2;
++		if (new_size < min_size + 8)
++			new_size = min_size + 8;
++	}
+ #ifdef PRINTBUF_DEBUG
+ 	MC_DEBUG("printbuf_memappend: realloc "
+ 	         "bpos=%d min_size=%d old_size=%d new_size=%d\n",
+@@ -83,6 +90,9 @@ static int printbuf_extend(struct printbuf *p, int min_size)
+ 
+ int printbuf_memappend(struct printbuf *p, const char *buf, int size)
+ {
++	/* Prevent signed integer overflows with large buffers. */
++	if (size > INT_MAX - p->bpos - 1)
++		return -1;
+ 	if (p->size <= p->bpos + size + 1)
+ 	{
+ 		if (printbuf_extend(p, p->bpos + size + 1) < 0)
+@@ -100,6 +110,9 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
+ 
+ 	if (offset == -1)
+ 		offset = pb->bpos;
++	/* Prevent signed integer overflows with large buffers. */
++	if (len > INT_MAX - offset)
++		return -1;
+ 	size_needed = offset + len;
+ 	if (pb->size < size_needed)
+ 	{
+
+From 392770c8e5c0783185bdfe0d919737e705190904 Mon Sep 17 00:00:00 2001
+From: dota17 <chenguopingdota@163.com>
+Date: Wed, 6 May 2020 10:48:53 +0800
+Subject: [PATCH 09/18] support to build both static and shared libraries
+
+---
+ CMakeLists.txt | 20 ++++++++++++++++++++
+ README.md      | 10 +++++++++-
+ 2 files changed, 29 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea536947df..7d7bd7fcc4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -392,6 +392,26 @@ target_include_directories(${PROJECT_NAME}
+         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+ )
+ 
++# Allow to build static and shared libraries at the same time
++if (BUILD_STATIC_LIBS)
++    set(ORIGINAL_STATIC_LIB_NAME ${PROJECT_NAME}-static)
++    add_library(${ORIGINAL_STATIC_LIB_NAME} STATIC
++        ${JSON_C_SOURCES}
++        ${JSON_C_HEADERS}
++    )
++
++    # rename the static library
++    set_target_properties(${ORIGINAL_STATIC_LIB_NAME} PROPERTIES
++        OUTPUT_NAME ${PROJECT_NAME}
++    )
++
++    target_include_directories(${PROJECT_NAME}
++        PUBLIC
++            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
++            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
++    )
++endif ()
++
+ # Always create new install dirs with 0755 permissions, regardless of umask
+ set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
+ 	OWNER_READ
+diff --git a/README.md b/README.md
+index 39ea0d6814..909fd116bf 100644
+--- a/README.md
++++ b/README.md
+@@ -98,6 +98,7 @@ Variable             | Type   | Description
+ CMAKE_INSTALL_PREFIX | String | The install location.
+ CMAKE_BUILD_TYPE     | String | Defaults to "debug"
+ BUILD_SHARED_LIBS    | Bool   | The default build generates a dynamic (dll/so) library.  Set this to OFF to create a static library instead.
++BUILD_STATIC_LIBS    | Bool   | This build generates a static (lib/a) library.
+ ENABLE_RDRAND        | Bool   | Enable RDRAND Hardware RNG Hash Seed
+ ENABLE_THREADING     | Bool   | Enable partial threading support
+ DISABLE_WERROR       | Bool   | Disable use of -Werror
+@@ -106,7 +107,14 @@ DISABLE_BSYMBOLIC    | Bool   | Disable use of -Bsymbolic-functions
+ Pass these options as `-D` on CMake's command-line.
+ 
+ ```sh
+-cmake -DBUILD_SHARED_LIBS=OFF ...
++# build a static library
++cmake -DBUILD_SHARED_LIBS=OFF ..
++```
++
++Allow to build both static and shared libraries.
++
++```sh
++cmake -DBUILD_STATIC_LIBS=ON ..
+ ```
+ 
+ ### Building with partial threading support
+
+From af7a3e05af5e7410c1d8e00ec10b728db737843a Mon Sep 17 00:00:00 2001
+From: dota17 <chenguopingdota@163.com>
+Date: Thu, 7 May 2020 14:50:43 +0800
+Subject: [PATCH 10/18] update
+
+---
+ CMakeLists.txt |  7 +------
+ README.md      | 12 +++---------
+ 2 files changed, 4 insertions(+), 15 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7d7bd7fcc4..f82103879a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65,6 +65,7 @@ include(GNUInstallDirs)
+ include(CMakePackageConfigHelpers)
+ 
+ option(BUILD_SHARED_LIBS  "Default to building shared libraries" ON)
++option(BUILD_STATIC_LIBS  "Default to building static libraries" ON)
+ 
+ # Generate a release merge and test it to verify the correctness of republishing the package.
+ ADD_CUSTOM_TARGET(distcheck
+@@ -404,12 +405,6 @@ if (BUILD_STATIC_LIBS)
+     set_target_properties(${ORIGINAL_STATIC_LIB_NAME} PROPERTIES
+         OUTPUT_NAME ${PROJECT_NAME}
+     )
+-
+-    target_include_directories(${PROJECT_NAME}
+-        PUBLIC
+-            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+-            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+-    )
+ endif ()
+ 
+ # Always create new install dirs with 0755 permissions, regardless of umask
+diff --git a/README.md b/README.md
+index 909fd116bf..f5a7ee39b4 100644
+--- a/README.md
++++ b/README.md
+@@ -97,8 +97,8 @@ Variable             | Type   | Description
+ ---------------------|--------|--------------
+ CMAKE_INSTALL_PREFIX | String | The install location.
+ CMAKE_BUILD_TYPE     | String | Defaults to "debug"
+-BUILD_SHARED_LIBS    | Bool   | The default build generates a dynamic (dll/so) library.  Set this to OFF to create a static library instead.
+-BUILD_STATIC_LIBS    | Bool   | This build generates a static (lib/a) library.
++BUILD_SHARED_LIBS    | Bool   | The default build generates a dynamic (dll/so) library.  Set this to OFF to create a static library only.
++BUILD_STATIC_LIBS    | Bool   | The default build generates a static (lib/a) library.  Set this to OFF to create a shared library only.
+ ENABLE_RDRAND        | Bool   | Enable RDRAND Hardware RNG Hash Seed
+ ENABLE_THREADING     | Bool   | Enable partial threading support
+ DISABLE_WERROR       | Bool   | Disable use of -Werror
+@@ -107,16 +107,10 @@ DISABLE_BSYMBOLIC    | Bool   | Disable use of -Bsymbolic-functions
+ Pass these options as `-D` on CMake's command-line.
+ 
+ ```sh
+-# build a static library
++# build a static library only
+ cmake -DBUILD_SHARED_LIBS=OFF ..
+ ```
+ 
+-Allow to build both static and shared libraries.
+-
+-```sh
+-cmake -DBUILD_STATIC_LIBS=ON ..
+-```
+-
+ ### Building with partial threading support
+ 
+ Although json-c does not support fully multi-threaded access to
+
+From 077eceead18152fae8c6bd8e2288d53d5eba7cf6 Mon Sep 17 00:00:00 2001
+From: hofnarr <hofnarr@hofnarr.fi>
+Date: Fri, 8 May 2020 02:16:52 +0300
+Subject: [PATCH 11/18] cmake: add list for build targets
+
+---
+ CMakeLists.txt | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f82103879a..00613a8d67 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -384,7 +384,7 @@ add_library(${PROJECT_NAME}
+ set_target_properties(${PROJECT_NAME} PROPERTIES
+     VERSION 5.0.0
+     SOVERSION 5)
+-
++list(APPEND CMAKE_TARGETS ${PROJECT_NAME})
+ # If json-c is used as subroject it set to target correct interface -I flags and allow
+ # to build external target without extra include_directories(...)
+ target_include_directories(${PROJECT_NAME}
+@@ -405,6 +405,7 @@ if (BUILD_STATIC_LIBS)
+     set_target_properties(${ORIGINAL_STATIC_LIB_NAME} PROPERTIES
+         OUTPUT_NAME ${PROJECT_NAME}
+     )
++    list(APPEND CMAKE_TARGETS ${STATIC_LIB})
+ endif ()
+ 
+ # Always create new install dirs with 0755 permissions, regardless of umask
+@@ -418,7 +419,7 @@ set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
+ 	WORLD_EXECUTE
+    )
+ 
+-install(TARGETS ${PROJECT_NAME}
++install(TARGETS ${CMAKE_TARGETS}
+     EXPORT ${PROJECT_NAME}-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+
+From 20895f941ee4e1ffe8248c30c01322970479d7cd Mon Sep 17 00:00:00 2001
+From: hofnarr <hofnarr@hofnarr.fi>
+Date: Fri, 8 May 2020 02:19:38 +0300
+Subject: [PATCH 12/18] cmake: change variable name
+
+---
+ CMakeLists.txt | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 00613a8d67..7302d4edf0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -395,14 +395,14 @@ target_include_directories(${PROJECT_NAME}
+ 
+ # Allow to build static and shared libraries at the same time
+ if (BUILD_STATIC_LIBS)
+-    set(ORIGINAL_STATIC_LIB_NAME ${PROJECT_NAME}-static)
+-    add_library(${ORIGINAL_STATIC_LIB_NAME} STATIC
++    set(STATIC_LIB ${PROJECT_NAME}-static)
++    add_library(${STATIC_LIB} STATIC
+         ${JSON_C_SOURCES}
+         ${JSON_C_HEADERS}
+     )
+ 
+     # rename the static library
+-    set_target_properties(${ORIGINAL_STATIC_LIB_NAME} PROPERTIES
++    set_target_properties(${STATIC_LIB} PROPERTIES
+         OUTPUT_NAME ${PROJECT_NAME}
+     )
+     list(APPEND CMAKE_TARGETS ${STATIC_LIB})
+
+From 2db5633de4980a33c911e9a52984ac62f2a5edf7 Mon Sep 17 00:00:00 2001
+From: hofnarr <hofnarr@hofnarr.fi>
+Date: Fri, 8 May 2020 02:27:06 +0300
+Subject: [PATCH 13/18] cmake-configure: fix enable-static option
+
+---
+ cmake-configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake-configure b/cmake-configure
+index 2fcc39e3ca..c8e44aeed4 100755
+--- a/cmake-configure
++++ b/cmake-configure
+@@ -65,7 +65,7 @@ while [ $# -gt 0 ] ; do
+ 		FLAGS+=(-DBUILD_SHARED_LIBS=ON)
+ 		;;
+ 	--enable-static)
+-		FLAGS+=(-DBUILD_SHARED_LIBS=OFF)
++		FLAGS+=(-DBUILD_STATIC_LIBS=ON)
+ 		;;
+ 	--disable-Bsymbolic)
+ 		FLAGS+=(-DDISABLE_BSYMBOLIC=ON)
+
+From 7a4807fe0cdb1d9e20273c79762cbf54833aaae4 Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Sun, 10 May 2020 03:32:19 +0000
+Subject: [PATCH 14/18] Issue #599: Fix the backwards check in
+ lh_table_insert_w_hash() that was preventing adding more than 11 objects. Add
+ a test to check for this too.
+
+---
+ linkhash.c           |  2 +-
+ tests/test4.c        | 29 +++++++++++++++++++++++++++++
+ tests/test4.expected |  1 +
+ 3 files changed, 31 insertions(+), 1 deletion(-)
+
+diff --git a/linkhash.c b/linkhash.c
+index 51e90b13a2..f930efd387 100644
+--- a/linkhash.c
++++ b/linkhash.c
+@@ -582,7 +582,7 @@ int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v, con
+ 
+ 	if (t->count >= t->size * LH_LOAD_FACTOR) {
+ 		/* Avoid signed integer overflow with large tables. */
+-		int new_size = INT_MAX / 2 < t->size ? t->size * 2 : INT_MAX;
++		int new_size = (t->size > INT_MAX / 2) ? INT_MAX : (t->size * 2);
+ 		if (t->size == INT_MAX || lh_table_resize(t, new_size) != 0)
+ 			return -1;
+ 	}
+diff --git a/tests/test4.c b/tests/test4.c
+index bd964ec789..fd2f3be8ec 100644
+--- a/tests/test4.c
++++ b/tests/test4.c
+@@ -3,8 +3,10 @@
+  */
+ 
+ #include "config.h"
++#include <assert.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <stdlib.h>
+ 
+ #include "json_inttypes.h"
+ #include "json_object.h"
+@@ -24,6 +26,30 @@ void print_hex(const char *s)
+ 	putchar('\n');
+ }
+ 
++static void test_lot_of_adds(void);
++static void test_lot_of_adds()
++{
++	int ii;
++	char key[50];
++	json_object *jobj = json_object_new_object();
++	assert(jobj != NULL);
++	for (ii = 0; ii < 500; ii++)
++	{
++		snprintf(key, sizeof(key), "k%d", ii);
++		json_object *iobj = json_object_new_int(ii);
++		assert(iobj != NULL);
++		if (json_object_object_add(jobj, key, iobj))
++		{
++			fprintf(stderr, "FAILED to add object #%d\n", ii);
++			abort();
++		}
++	}
++	printf("%s\n", json_object_to_json_string(jobj));
++	assert(json_object_object_length(jobj) == 500);
++	json_object_put(jobj);
++}
++
++
+ int main(void)
+ {
+ 	const char *input = "\"\\ud840\\udd26,\\ud840\\udd27,\\ud800\\udd26,\\ud800\\udd27\"";
+@@ -52,5 +78,8 @@ int main(void)
+ 		retval = 1;
+ 	}
+ 	json_object_put(parse_result);
++
++	test_lot_of_adds();
++
+ 	return retval;
+ }
+diff --git a/tests/test4.expected b/tests/test4.expected
+index 68d4336d90..cb2744012b 100644
+--- a/tests/test4.expected
++++ b/tests/test4.expected
+@@ -1,3 +1,4 @@
+ input: "\ud840\udd26,\ud840\udd27,\ud800\udd26,\ud800\udd27"
+ JSON parse result is correct: 𠄦,𠄧,𐄦,𐄧
+ PASS
++{ "k0": 0, "k1": 1, "k2": 2, "k3": 3, "k4": 4, "k5": 5, "k6": 6, "k7": 7, "k8": 8, "k9": 9, "k10": 10, "k11": 11, "k12": 12, "k13": 13, "k14": 14, "k15": 15, "k16": 16, "k17": 17, "k18": 18, "k19": 19, "k20": 20, "k21": 21, "k22": 22, "k23": 23, "k24": 24, "k25": 25, "k26": 26, "k27": 27, "k28": 28, "k29": 29, "k30": 30, "k31": 31, "k32": 32, "k33": 33, "k34": 34, "k35": 35, "k36": 36, "k37": 37, "k38": 38, "k39": 39, "k40": 40, "k41": 41, "k42": 42, "k43": 43, "k44": 44, "k45": 45, "k46": 46, "k47": 47, "k48": 48, "k49": 49, "k50": 50, "k51": 51, "k52": 52, "k53": 53, "k54": 54, "k55": 55, "k56": 56, "k57": 57, "k58": 58, "k59": 59, "k60": 60, "k61": 61, "k62": 62, "k63": 63, "k64": 64, "k65": 65, "k66": 66, "k67": 67, "k68": 68, "k69": 69, "k70": 70, "k71": 71, "k72": 72, "k73": 73, "k74": 74, "k75": 75, "k76": 76, "k77": 77, "k78": 78, "k79": 79, "k80": 80, "k81": 81, "k82": 82, "k83": 83, "k84": 84, "k85": 85, "k86": 86, "k87": 87, "k88": 88, "k89": 89, "k90": 90, "k91": 91, "k92": 92, "k93": 93, "k94": 94, "k95": 95, "k96": 96, "k97": 97, "k98": 98, "k99": 99, "k100": 100, "k101": 101, "k102": 102, "k103": 103, "k104": 104, "k105": 105, "k106": 106, "k107": 107, "k108": 108, "k109": 109, "k110": 110, "k111": 111, "k112": 112, "k113": 113, "k114": 114, "k115": 115, "k116": 116, "k117": 117, "k118": 118, "k119": 119, "k120": 120, "k121": 121, "k122": 122, "k123": 123, "k124": 124, "k125": 125, "k126": 126, "k127": 127, "k128": 128, "k129": 129, "k130": 130, "k131": 131, "k132": 132, "k133": 133, "k134": 134, "k135": 135, "k136": 136, "k137": 137, "k138": 138, "k139": 139, "k140": 140, "k141": 141, "k142": 142, "k143": 143, "k144": 144, "k145": 145, "k146": 146, "k147": 147, "k148": 148, "k149": 149, "k150": 150, "k151": 151, "k152": 152, "k153": 153, "k154": 154, "k155": 155, "k156": 156, "k157": 157, "k158": 158, "k159": 159, "k160": 160, "k161": 161, "k162": 162, "k163": 163, "k164": 164, "k165": 165, "k166": 166, "k167": 167, "k168": 168, "k169": 169, "k170": 170, "k171": 171, "k172": 172, "k173": 173, "k174": 174, "k175": 175, "k176": 176, "k177": 177, "k178": 178, "k179": 179, "k180": 180, "k181": 181, "k182": 182, "k183": 183, "k184": 184, "k185": 185, "k186": 186, "k187": 187, "k188": 188, "k189": 189, "k190": 190, "k191": 191, "k192": 192, "k193": 193, "k194": 194, "k195": 195, "k196": 196, "k197": 197, "k198": 198, "k199": 199, "k200": 200, "k201": 201, "k202": 202, "k203": 203, "k204": 204, "k205": 205, "k206": 206, "k207": 207, "k208": 208, "k209": 209, "k210": 210, "k211": 211, "k212": 212, "k213": 213, "k214": 214, "k215": 215, "k216": 216, "k217": 217, "k218": 218, "k219": 219, "k220": 220, "k221": 221, "k222": 222, "k223": 223, "k224": 224, "k225": 225, "k226": 226, "k227": 227, "k228": 228, "k229": 229, "k230": 230, "k231": 231, "k232": 232, "k233": 233, "k234": 234, "k235": 235, "k236": 236, "k237": 237, "k238": 238, "k239": 239, "k240": 240, "k241": 241, "k242": 242, "k243": 243, "k244": 244, "k245": 245, "k246": 246, "k247": 247, "k248": 248, "k249": 249, "k250": 250, "k251": 251, "k252": 252, "k253": 253, "k254": 254, "k255": 255, "k256": 256, "k257": 257, "k258": 258, "k259": 259, "k260": 260, "k261": 261, "k262": 262, "k263": 263, "k264": 264, "k265": 265, "k266": 266, "k267": 267, "k268": 268, "k269": 269, "k270": 270, "k271": 271, "k272": 272, "k273": 273, "k274": 274, "k275": 275, "k276": 276, "k277": 277, "k278": 278, "k279": 279, "k280": 280, "k281": 281, "k282": 282, "k283": 283, "k284": 284, "k285": 285, "k286": 286, "k287": 287, "k288": 288, "k289": 289, "k290": 290, "k291": 291, "k292": 292, "k293": 293, "k294": 294, "k295": 295, "k296": 296, "k297": 297, "k298": 298, "k299": 299, "k300": 300, "k301": 301, "k302": 302, "k303": 303, "k304": 304, "k305": 305, "k306": 306, "k307": 307, "k308": 308, "k309": 309, "k310": 310, "k311": 311, "k312": 312, "k313": 313, "k314": 314, "k315": 315, "k316": 316, "k317": 317, "k318": 318, "k319": 319, "k320": 320, "k321": 321, "k322": 322, "k323": 323, "k324": 324, "k325": 325, "k326": 326, "k327": 327, "k328": 328, "k329": 329, "k330": 330, "k331": 331, "k332": 332, "k333": 333, "k334": 334, "k335": 335, "k336": 336, "k337": 337, "k338": 338, "k339": 339, "k340": 340, "k341": 341, "k342": 342, "k343": 343, "k344": 344, "k345": 345, "k346": 346, "k347": 347, "k348": 348, "k349": 349, "k350": 350, "k351": 351, "k352": 352, "k353": 353, "k354": 354, "k355": 355, "k356": 356, "k357": 357, "k358": 358, "k359": 359, "k360": 360, "k361": 361, "k362": 362, "k363": 363, "k364": 364, "k365": 365, "k366": 366, "k367": 367, "k368": 368, "k369": 369, "k370": 370, "k371": 371, "k372": 372, "k373": 373, "k374": 374, "k375": 375, "k376": 376, "k377": 377, "k378": 378, "k379": 379, "k380": 380, "k381": 381, "k382": 382, "k383": 383, "k384": 384, "k385": 385, "k386": 386, "k387": 387, "k388": 388, "k389": 389, "k390": 390, "k391": 391, "k392": 392, "k393": 393, "k394": 394, "k395": 395, "k396": 396, "k397": 397, "k398": 398, "k399": 399, "k400": 400, "k401": 401, "k402": 402, "k403": 403, "k404": 404, "k405": 405, "k406": 406, "k407": 407, "k408": 408, "k409": 409, "k410": 410, "k411": 411, "k412": 412, "k413": 413, "k414": 414, "k415": 415, "k416": 416, "k417": 417, "k418": 418, "k419": 419, "k420": 420, "k421": 421, "k422": 422, "k423": 423, "k424": 424, "k425": 425, "k426": 426, "k427": 427, "k428": 428, "k429": 429, "k430": 430, "k431": 431, "k432": 432, "k433": 433, "k434": 434, "k435": 435, "k436": 436, "k437": 437, "k438": 438, "k439": 439, "k440": 440, "k441": 441, "k442": 442, "k443": 443, "k444": 444, "k445": 445, "k446": 446, "k447": 447, "k448": 448, "k449": 449, "k450": 450, "k451": 451, "k452": 452, "k453": 453, "k454": 454, "k455": 455, "k456": 456, "k457": 457, "k458": 458, "k459": 459, "k460": 460, "k461": 461, "k462": 462, "k463": 463, "k464": 464, "k465": 465, "k466": 466, "k467": 467, "k468": 468, "k469": 469, "k470": 470, "k471": 471, "k472": 472, "k473": 473, "k474": 474, "k475": 475, "k476": 476, "k477": 477, "k478": 478, "k479": 479, "k480": 480, "k481": 481, "k482": 482, "k483": 483, "k484": 484, "k485": 485, "k486": 486, "k487": 487, "k488": 488, "k489": 489, "k490": 490, "k491": 491, "k492": 492, "k493": 493, "k494": 494, "k495": 495, "k496": 496, "k497": 497, "k498": 498, "k499": 499 }
+
+From b4c0c8d0270155a37f192033786b7602245eb923 Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Sun, 10 May 2020 03:48:45 +0000
+Subject: [PATCH 15/18] Issue #598: avoid building static libraries twice.
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7302d4edf0..67c2ae6e7c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -394,7 +394,7 @@ target_include_directories(${PROJECT_NAME}
+ )
+ 
+ # Allow to build static and shared libraries at the same time
+-if (BUILD_STATIC_LIBS)
++if (BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS)
+     set(STATIC_LIB ${PROJECT_NAME}-static)
+     add_library(${STATIC_LIB} STATIC
+         ${JSON_C_SOURCES}
+
+From 5d3466d0cb709da0f84b1010c4658a87805db47f Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Sun, 10 May 2020 03:58:27 +0000
+Subject: [PATCH 16/18] Re-format after recent change to fix linkhash.
+
+---
+ linkhash.c    | 3 ++-
+ tests/test4.c | 3 +--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/linkhash.c b/linkhash.c
+index f930efd387..b021ef10b0 100644
+--- a/linkhash.c
++++ b/linkhash.c
+@@ -580,7 +580,8 @@ int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v, con
+ {
+ 	unsigned long n;
+ 
+-	if (t->count >= t->size * LH_LOAD_FACTOR) {
++	if (t->count >= t->size * LH_LOAD_FACTOR)
++	{
+ 		/* Avoid signed integer overflow with large tables. */
+ 		int new_size = (t->size > INT_MAX / 2) ? INT_MAX : (t->size * 2);
+ 		if (t->size == INT_MAX || lh_table_resize(t, new_size) != 0)
+diff --git a/tests/test4.c b/tests/test4.c
+index fd2f3be8ec..7d3d0be168 100644
+--- a/tests/test4.c
++++ b/tests/test4.c
+@@ -5,8 +5,8 @@
+ #include "config.h"
+ #include <assert.h>
+ #include <stdio.h>
+-#include <string.h>
+ #include <stdlib.h>
++#include <string.h>
+ 
+ #include "json_inttypes.h"
+ #include "json_object.h"
+@@ -49,7 +49,6 @@ static void test_lot_of_adds()
+ 	json_object_put(jobj);
+ }
+ 
+-
+ int main(void)
+ {
+ 	const char *input = "\"\\ud840\\udd26,\\ud840\\udd27,\\ud800\\udd26,\\ud800\\udd27\"";
+
+From f0bbaec2d4e1c64bcc2b4e9880d15ccb46233fc0 Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Sun, 10 May 2020 03:58:51 +0000
+Subject: [PATCH 17/18] Issue #600: don't rename the static library on Windows,
+ it _needs_ to have a different name because the dll build also creates a
+ "json-c.lib" file.
+
+---
+ CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 67c2ae6e7c..b980a5a2f8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -402,9 +402,11 @@ if (BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS)
+     )
+ 
+     # rename the static library
++    if (NOT MSVC)
+     set_target_properties(${STATIC_LIB} PROPERTIES
+         OUTPUT_NAME ${PROJECT_NAME}
+     )
++    endif()
+     list(APPEND CMAKE_TARGETS ${STATIC_LIB})
+ endif ()
+ 
+
+From c7c7d1cbe93a978898c0f270948369bb8ec9cc05 Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Sun, 10 May 2020 04:04:28 +0000
+Subject: [PATCH 18/18] Fix snprintf on windows problem for test4.
+
+---
+ tests/test4.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/test4.c b/tests/test4.c
+index 7d3d0be168..288cec1792 100644
+--- a/tests/test4.c
++++ b/tests/test4.c
+@@ -11,6 +11,7 @@
+ #include "json_inttypes.h"
+ #include "json_object.h"
+ #include "json_tokener.h"
++#include "snprintf_compat.h"
+ 
+ void print_hex(const char *s)
+ {

--- a/SOURCES/json-c-0.14-cmake_fix_out_of_tree_build_for_Doxygen_documentation.patch
+++ b/SOURCES/json-c-0.14-cmake_fix_out_of_tree_build_for_Doxygen_documentation.patch
@@ -1,0 +1,59 @@
+From 8f3592b3d59874b4dd230a741fad3ffa99223a45 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Esser?= <besser82@fedoraproject.org>
+Date: Mon, 18 May 2020 18:20:01 +0200
+Subject: [PATCH] CMake: Fix out-of-tree build for Doxygen documentation.
+
+---
+ CMakeLists.txt          | 9 +++++----
+ Doxyfile => Doxyfile.in | 4 ++--
+ 2 files changed, 7 insertions(+), 6 deletions(-)
+ rename Doxyfile => Doxyfile.in (99%)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 901eb6e364..f58301c71a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -368,13 +368,14 @@ option(BUILD_DOCUMENTATION "Create and install the HTML based API documentation(
+ 
+ if (DOXYGEN_FOUND)
+ 
++	configure_file(${PROJECT_SOURCE_DIR}/Doxyfile.in
++	  ${PROJECT_BINARY_DIR}/Doxyfile)
++	message(STATUS "Written ${PROJECT_BINARY_DIR}/Doxyfile")
++
+ 	add_custom_target(doc
+-	COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_SOURCE_DIR}/Doxyfile
++	COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
+ 		WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+ 
+-	# request to configure the file
+-	configure_file(Doxyfile Doxyfile)
+-
+ else (DOXYGEN_FOUND)
+ 	message("Warning: doxygen not found, the 'doc' target will not be included")
+ endif(DOXYGEN_FOUND)
+diff --git a/Doxyfile b/Doxyfile.in
+similarity index 99%
+rename from Doxyfile
+rename to Doxyfile.in
+index 06d54e661e..42a08535c2 100644
+--- a/Doxyfile
++++ b/Doxyfile.in
+@@ -38,7 +38,7 @@ PROJECT_NAME           = json-c
+ # could be handy for archiving the generated documentation or if some version
+ # control system is used.
+ 
+-PROJECT_NUMBER         = 0.14
++PROJECT_NUMBER         = @PROJECT_VERSION@
+ 
+ # Using the PROJECT_BRIEF tag one can provide an optional one line description
+ # for a project that appears at the top of each page and should give viewer a
+@@ -753,7 +753,7 @@ WARN_LOGFILE           =
+ # spaces.
+ # Note: If this tag is empty the current directory is searched.
+ 
+-INPUT                  =
++INPUT                  = @CMAKE_SOURCE_DIR@ @CMAKE_BINARY_DIR@
+ 
+ # This tag can be used to specify the character encoding of the source files
+ # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/SOURCES/json-c-0.14-dont_install_config_h.patch
+++ b/SOURCES/json-c-0.14-dont_install_config_h.patch
@@ -1,0 +1,23 @@
+From 228881c8fc287182f284a58d8279a32fbeae0b7f Mon Sep 17 00:00:00 2001
+From: Eric Haszlakiewicz <erh+git@nimenees.com>
+Date: Tue, 21 Apr 2020 01:13:21 +0000
+Subject: [PATCH] Issue #585: don't install config.h
+
+(cherry picked from commit 8b511c402b73d1d8b195991891c8d44859cb57ec)
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba692fff69..c51f477c5f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -299,7 +299,7 @@ if ($ENV{VALGRIND})
+ endif()
+ 
+ set(JSON_C_PUBLIC_HEADERS
+-    ${PROJECT_BINARY_DIR}/config.h
++    # Note: config.h is _not_ included here
+     ${PROJECT_BINARY_DIR}/json_config.h
+ 
+     ${PROJECT_SOURCE_DIR}/json.h

--- a/SOURCES/json-c-0.14-fix_usage_of_errno_in_json_parse_uint64.patch
+++ b/SOURCES/json-c-0.14-fix_usage_of_errno_in_json_parse_uint64.patch
@@ -1,0 +1,74 @@
+From 003b58782b12798da3da8b952152988a88dfb532 Mon Sep 17 00:00:00 2001
+From: Pierce Lopez <pierce.lopez@gmail.com>
+Date: Sun, 10 May 2020 13:20:02 -0400
+Subject: [PATCH] fix json_parse_uint64() usage of errno
+
+introduced in #542
+fixes #601
+---
+ json_util.c                     | 8 +++-----
+ json_util.h                     | 1 +
+ tests/test_parse_int64.expected | 8 ++++----
+ 3 files changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/json_util.c b/json_util.c
+index d3ee47df72..e8e2ec6bcb 100644
+--- a/json_util.c
++++ b/json_util.c
+@@ -245,19 +245,17 @@ int json_parse_uint64(const char *buf, uint64_t *retval)
+ {
+ 	char *end = NULL;
+ 	uint64_t val;
+-	errno = 1;
+ 
++	errno = 0;
+ 	while (*buf == ' ')
+-	{
+ 		buf++;
+-	}
+ 	if (*buf == '-')
+-		errno = 0;
++		return 1;  /* error: uint cannot be negative */
+ 
+ 	val = strtoull(buf, &end, 10);
+ 	if (end != buf)
+ 		*retval = val;
+-	return ((errno == 0) || (end == buf)) ? 1 : 0;
++	return ((val == 0 && errno != 0) || (end == buf)) ? 1 : 0;
+ }
+ 
+ #ifndef HAVE_REALLOC
+diff --git a/json_util.h b/json_util.h
+index 2a4b6c19bd..7520f036c4 100644
+--- a/json_util.h
++++ b/json_util.h
+@@ -100,6 +100,7 @@ JSON_EXPORT int json_object_to_fd(int fd, struct json_object *obj, int flags);
+  */
+ JSON_EXPORT const char *json_util_get_last_err(void);
+ 
++/* these parsing helpers return zero on success */
+ JSON_EXPORT int json_parse_int64(const char *buf, int64_t *retval);
+ JSON_EXPORT int json_parse_uint64(const char *buf, uint64_t *retval);
+ JSON_EXPORT int json_parse_double(const char *buf, double *retval);
+diff --git a/tests/test_parse_int64.expected b/tests/test_parse_int64.expected
+index f4c5750b0b..6dca94b470 100644
+--- a/tests/test_parse_int64.expected
++++ b/tests/test_parse_int64.expected
+@@ -34,13 +34,13 @@ buf=123 parseit=0, value=123
+ ==========json_parse_uint64() test===========
+ buf=x parseit=1, value=666 
+ buf=0 parseit=0, value=0 
+-buf=-0 parseit=1, value=0 
++buf=-0 parseit=1, value=666 
+ buf=00000000 parseit=0, value=0 
+-buf=-00000000 parseit=1, value=0 
++buf=-00000000 parseit=1, value=666 
+ buf=1 parseit=0, value=1 
+ buf=2147483647 parseit=0, value=2147483647 
+-buf=-1 parseit=1, value=18446744073709551615 
+-buf=-9223372036854775808 parseit=1, value=9223372036854775808 
++buf=-1 parseit=1, value=666 
++buf=-9223372036854775808 parseit=1, value=666 
+ buf=   1 parseit=0, value=1 
+ buf=00001234 parseit=0, value=1234 
+ buf=0001234x parseit=0, value=1234 

--- a/SOURCES/json-c-0.14-move_Doxyfile_into_doc_subdir.patch
+++ b/SOURCES/json-c-0.14-move_Doxyfile_into_doc_subdir.patch
@@ -1,0 +1,121 @@
+From 61e2bae5111b49a788fe4c236b473dc86250a7fe Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Esser?= <besser82@fedoraproject.org>
+Date: Mon, 18 May 2020 20:32:35 +0200
+Subject: [PATCH 1/2] doc: Move Doxyfile into doc subdir
+
+---
+ .gitignore                     |  2 +-
+ CMakeLists.txt                 | 19 +------------------
+ doc/CMakeLists.txt             | 16 ++++++++++++++++
+ Doxyfile.in => doc/Doxyfile.in |  2 +-
+ 4 files changed, 19 insertions(+), 20 deletions(-)
+ create mode 100644 doc/CMakeLists.txt
+ rename Doxyfile.in => doc/Doxyfile.in (99%)
+
+diff --git a/.gitignore b/.gitignore
+index 958ace3ac1..1cdaf9bdba 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -83,7 +83,7 @@
+ /Testing/
+ 
+ # ...and build artifacts.
+-/doc
++/doc/html
+ /libjson-c.a
+ /libjson-c.so
+ /libjson-c.so.*
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f58301c71a..ec17697170 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -361,24 +361,7 @@ set(JSON_C_SOURCES
+ include_directories(${PROJECT_SOURCE_DIR})
+ include_directories(${PROJECT_BINARY_DIR})
+ 
+-# generate doxygen documentation for json-c API
+-
+-find_package(Doxygen)
+-option(BUILD_DOCUMENTATION "Create and install the HTML based API documentation(requires Doxygen)" ${DOXYGEN_FOUND})
+-
+-if (DOXYGEN_FOUND)
+-
+-	configure_file(${PROJECT_SOURCE_DIR}/Doxyfile.in
+-	  ${PROJECT_BINARY_DIR}/Doxyfile)
+-	message(STATUS "Written ${PROJECT_BINARY_DIR}/Doxyfile")
+-
+-	add_custom_target(doc
+-	COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
+-		WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+-
+-else (DOXYGEN_FOUND)
+-	message("Warning: doxygen not found, the 'doc' target will not be included")
+-endif(DOXYGEN_FOUND)
++add_subdirectory(doc)
+ 
+ # uninstall
+ add_custom_target(uninstall
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+new file mode 100644
+index 0000000000..4872d8e8ad
+--- /dev/null
++++ b/doc/CMakeLists.txt
+@@ -0,0 +1,16 @@
++# generate doxygen documentation for json-c API
++
++find_package(Doxygen)
++
++if (DOXYGEN_FOUND)
++
++	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
++	  ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
++	message(STATUS "Wrote ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile")
++
++	add_custom_target(doc
++	COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
++
++else (DOXYGEN_FOUND)
++	message("Warning: doxygen not found, the 'doc' target will not be included")
++endif(DOXYGEN_FOUND)
+diff --git a/Doxyfile.in b/doc/Doxyfile.in
+similarity index 99%
+rename from Doxyfile.in
+rename to doc/Doxyfile.in
+index 42a08535c2..ce8d8ff78c 100644
+--- a/Doxyfile.in
++++ b/doc/Doxyfile.in
+@@ -58,7 +58,7 @@ PROJECT_LOGO           =
+ # entered, it will be relative to the location where doxygen was started. If
+ # left blank the current directory will be used.
+ 
+-OUTPUT_DIRECTORY       = doc
++OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@
+ 
+ # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
+ # directories (in 2 levels) under the output directory of each output format and
+
+From 1e94da779a9aa107690e4f2921ab4d0300aca579 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Esser?= <besser82@fedoraproject.org>
+Date: Mon, 18 May 2020 20:36:05 +0200
+Subject: [PATCH 2/2] CMake: Fix grammar: written -> wrote.
+
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec17697170..333513c5e0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -237,9 +237,9 @@ endif()
+ 
+ # Once we've done basic symbol/header searches let's add them in.
+ configure_file(${PROJECT_SOURCE_DIR}/cmake/config.h.in        ${PROJECT_BINARY_DIR}/config.h)
+-message(STATUS "Written ${PROJECT_BINARY_DIR}/config.h")
++message(STATUS "Wrote ${PROJECT_BINARY_DIR}/config.h")
+ configure_file(${PROJECT_SOURCE_DIR}/cmake/json_config.h.in   ${PROJECT_BINARY_DIR}/json_config.h)
+-message(STATUS "Written ${PROJECT_BINARY_DIR}/json_config.h")
++message(STATUS "Wrote ${PROJECT_BINARY_DIR}/json_config.h")
+ 
+ if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+     set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections")

--- a/SOURCES/json-c-0.14-test_deep_copy_fix_assertion_value.patch
+++ b/SOURCES/json-c-0.14-test_deep_copy_fix_assertion_value.patch
@@ -1,0 +1,22 @@
+From 3008401b2a8f5b25bf5665cafa22b335d9ffdb3a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Esser?= <besser82@fedoraproject.org>
+Date: Mon, 18 May 2020 17:00:17 +0200
+Subject: [PATCH] test_deep_copy: Fix assertion value.
+
+---
+ tests/test_deep_copy.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test_deep_copy.c b/tests/test_deep_copy.c
+index b6c1b999f4..34ef1fe5d3 100644
+--- a/tests/test_deep_copy.c
++++ b/tests/test_deep_copy.c
+@@ -126,7 +126,7 @@ int main(int argc, char **argv)
+ 	src3 = json_tokener_parse(json_str3);
+ 
+ 	assert(src1 != NULL);
+-	assert(src1 != NULL);
++	assert(src2 != NULL);
+ 	assert(src3 != NULL);
+ 
+ 	printf("PASSED - loaded input data\n");

--- a/SOURCES/json-c-0.14-versioned-symbols.patch
+++ b/SOURCES/json-c-0.14-versioned-symbols.patch
@@ -1,0 +1,187 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 21e395ed3c..da0af963ed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -325,6 +325,22 @@ if (NOT ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC"))
+ 		# XXX need cmake>=3.13 for this:
+ 		#add_link_options("-Wl,-Bsymbolic-functions")
+ 	endif()
++
++	file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/check-version-script.sym" "TEST { global: *; };")
++	list(APPEND CMAKE_REQUIRED_LIBRARIES "-Wl,--version-script,${CMAKE_CURRENT_BINARY_DIR}/check-version-script.sym")
++	check_c_source_compiles(
++	"
++	int main (void)
++	{
++	  return 0;
++	}
++	"
++	VERSION_SCRIPT_WORKS
++	)
++	list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "-Wl,--version-script,${CMAKE_CURRENT_BINARY_DIR}/check-version-script.sym")
++	if (VERSION_SCRIPT_WORKS)
++		set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/json-c.sym")
++	endif()
+ endif()
+ 
+ if ($ENV{VALGRIND})
+diff --git a/json-c.sym b/json-c.sym
+new file mode 100644
+index 0000000000..bf78792b7e
+--- /dev/null
++++ b/json-c.sym
+@@ -0,0 +1,153 @@
++JSONC_0.14 {
++  global:
++    _json_c_set_last_err;
++    _json_c_strerror;
++    _json_c_strerror_enable;
++    array_list_add;
++    array_list_bsearch;
++    array_list_del_idx;
++    array_list_free;
++    array_list_get_idx;
++    array_list_length;
++    array_list_new;
++    array_list_put_idx;
++    array_list_sort;
++    json_c_get_random_seed;
++    json_c_object_sizeof;
++    json_c_set_serialization_double_format;
++    json_c_shallow_copy_default;
++    json_c_version;
++    json_c_version_num;
++    json_c_visit;
++    json_global_set_string_hash;
++    json_hex_chars;
++    json_number_chars;
++    json_object_array_add;
++    json_object_array_bsearch;
++    json_object_array_del_idx;
++    json_object_array_get_idx;
++    json_object_array_length;
++    json_object_array_put_idx;
++    json_object_array_sort;
++    json_object_deep_copy;
++    json_object_double_to_json_string;
++    json_object_equal;
++    json_object_free_userdata;
++    json_object_from_fd;
++    json_object_from_fd_ex;
++    json_object_from_file;
++    json_object_get;
++    json_object_get_array;
++    json_object_get_boolean;
++    json_object_get_double;
++    json_object_get_int64;
++    json_object_get_int;
++    json_object_get_object;
++    json_object_get_string;
++    json_object_get_string_len;
++    json_object_get_type;
++    json_object_get_uint64;
++    json_object_get_userdata;
++    json_object_int_inc;
++    json_object_is_type;
++    json_object_iter_begin;
++    json_object_iter_end;
++    json_object_iter_equal;
++    json_object_iter_init_default;
++    json_object_iter_next;
++    json_object_iter_peek_name;
++    json_object_iter_peek_value;
++    json_object_new_array;
++    json_object_new_boolean;
++    json_object_new_double;
++    json_object_new_double_s;
++    json_object_new_int64;
++    json_object_new_int;
++    json_object_new_null;
++    json_object_new_object;
++    json_object_new_string;
++    json_object_new_string_len;
++    json_object_new_uint64;
++    json_object_object_add;
++    json_object_object_add_ex;
++    json_object_object_del;
++    json_object_object_get;
++    json_object_object_get_ex;
++    json_object_object_length;
++    json_object_put;
++    json_object_set_boolean;
++    json_object_set_double;
++    json_object_set_int64;
++    json_object_set_int;
++    json_object_set_serializer;
++    json_object_set_string;
++    json_object_set_string_len;
++    json_object_set_uint64;
++    json_object_set_userdata;
++    json_object_to_fd;
++    json_object_to_file;
++    json_object_to_file_ext;
++    json_object_to_json_string;
++    json_object_to_json_string_ext;
++    json_object_to_json_string_length;
++    json_object_userdata_to_json_string;
++    json_parse_double;
++    json_parse_int64;
++    json_parse_uint64;
++    json_pointer_get;
++    json_pointer_getf;
++    json_pointer_set;
++    json_pointer_setf;
++    json_tokener_error_desc;
++    json_tokener_free;
++    json_tokener_get_error;
++    json_tokener_get_parse_end;
++    json_tokener_new;
++    json_tokener_new_ex;
++    json_tokener_parse;
++    json_tokener_parse_ex;
++    json_tokener_parse_verbose;
++    json_tokener_reset;
++    json_tokener_set_flags;
++    json_type_to_name;
++    json_util_get_last_err;
++    lh_char_equal;
++    lh_kchar_table_new;
++    lh_kptr_table_new;
++    lh_ptr_equal;
++    lh_table_delete;
++    lh_table_delete_entry;
++    lh_table_free;
++    lh_table_insert;
++    lh_table_insert_w_hash;
++    lh_table_length;
++    lh_table_lookup;
++    lh_table_lookup_entry;
++    lh_table_lookup_entry_w_hash;
++    lh_table_lookup_ex;
++    lh_table_new;
++    lh_table_resize;
++    mc_debug;
++    mc_error;
++    mc_get_debug;
++    mc_info;
++    mc_set_debug;
++    mc_set_syslog;
++    printbuf_free;
++    printbuf_memappend;
++    printbuf_memset;
++    printbuf_new;
++    printbuf_reset;
++    sprintbuf;
++
++  local:
++    *;
++};
++
++JSONC_0.15 {
++  global:
++    array_list_new2;
++    array_list_shrink;
++    json_object_array_shrink;
++    json_object_new_array_ext;
++} JSONC_0.14;
+

--- a/SPECS/json-c.spec
+++ b/SPECS/json-c.spec
@@ -1,0 +1,369 @@
+%{!?_pkgdocdir:%global _pkgdocdir %{_docdir}/%{name}-%{version}}
+
+# We don't want accidental SONAME bumps.
+# When there is a SONAME bump in json-c, we need to request
+# a side-tag for bootstrap purposes:
+#
+# 1. Build a bootstrap build of the systemd package, and wait
+#    for it to be available inside the side-tag.
+# 2. Re-build the following build-chain for bootstrap:
+#    json-c : cryptsetup
+# 3. Untag the systemd bootstrap build from the side-tag, and
+#    disable bootstrapping in the systemd package.  Re-build
+#    the systemd package into Rawhide.
+# 4. Wait for the changes to populate and re-build the following
+#    chain into the side-tag:
+#    satyr : libdnf libreport
+# 5. Merge the side-tag using Bodhi.
+#
+# After that procedure any other cosumers can be re-build
+# in Rawhide as usual.
+%global so_ver 5
+
+# Releases are tagged with a date stamp.
+%global reldate 20200419
+
+
+Name:           json-c
+Version:        0.14
+Release:        11%{?dist}
+Summary:        JSON implementation in C
+
+License:        MIT
+URL:            https://github.com/%{name}/%{name}
+Source0:        %{url}/archive/%{name}-%{version}-%{reldate}.tar.gz
+
+# Cherry-picked from upstream.
+Patch0001:      %{url}/commit/228881c8fc287182f284a58d8279a32fbeae0b7f.patch#/%{name}-0.14-dont_install_config_h.patch
+Patch0002:      %{url}/pull/603.patch#/%{name}-0.14-backport_fixes_from_master.patch
+Patch0003:      %{url}/commit/003b58782b12798da3da8b952152988a88dfb532.patch#/%{name}-0.14-fix_usage_of_errno_in_json_parse_uint64.patch
+Patch0004:      %{url}/pull/618.patch#/%{name}-0.14-test_deep_copy_fix_assertion_value.patch
+Patch0005:      %{url}/pull/619.patch#/%{name}-0.14-cmake_fix_out_of_tree_build_for_Doxygen_documentation.patch
+Patch0006:      %{url}/pull/622.patch#/%{name}-0.14-move_Doxyfile_into_doc_subdir.patch
+Patch0007:      %{url}/commit/4a546e7b2f471157c6f479df1ef687864fcbd89e.patch#/%{name}-0.14-arraylist_optimizations.patch
+# Start providing versioned symbols
+# rhbz#2001067
+Patch0008:	json-c-0.14-versioned-symbols.patch
+
+BuildRequires:  cmake
+BuildRequires:  gcc
+BuildRequires:  ninja-build
+%ifarch %{valgrind_arches}
+BuildRequires:  valgrind
+%endif
+
+%description
+JSON-C implements a reference counting object model that allows you
+to easily construct JSON objects in C, output them as JSON formatted
+strings and parse JSON formatted strings back into the C representation
+of JSON objects.  It aims to conform to RFC 7159.
+
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+This package contains libraries and header files for
+developing applications that use %{name}.
+
+
+%package        doc
+Summary:        Reference manual for json-c
+
+BuildArch:      noarch
+
+BuildRequires:  doxygen
+BuildRequires:  hardlink
+
+%description    doc
+This package contains the reference manual for %{name}.
+
+
+%prep
+%autosetup -n %{name}-%{name}-%{version}-%{reldate} -p 1
+
+# Remove pre-built html documentation.
+rm -fr doc/html
+
+# Update Doxyfile.
+doxygen -s -u doc/Doxyfile.in
+
+
+%build
+%cmake \
+  -DBUILD_STATIC_LIBS:BOOL=OFF       \
+  -DCMAKE_BUILD_TYPE:STRING=RELEASE  \
+  -DCMAKE_C_FLAGS_RELEASE:STRING=""  \
+  -DDISABLE_BSYMBOLIC:BOOL=OFF       \
+  -DDISABLE_WERROR:BOOL=ON           \
+  -DENABLE_RDRAND:BOOL=ON            \
+  -DENABLE_THREADING:BOOL=ON         \
+  -G Ninja
+%cmake_build --target all doc
+
+
+%install
+%cmake_install
+
+# Documentation
+mkdir -p %{buildroot}%{_pkgdocdir}
+cp -a %{__cmake_builddir}/doc/html ChangeLog README README.* \
+  %{buildroot}%{_pkgdocdir}
+hardlink -cfv %{buildroot}%{_pkgdocdir}
+
+
+%check
+export USE_VALGRIND=0
+%ctest
+%ifarch %{valgrind_arches}
+export USE_VALGRIND=1
+%ctest
+%endif
+unset USE_VALGRIND
+
+
+%ldconfig_scriptlets
+
+
+%files
+%license AUTHORS
+%license COPYING
+%{_libdir}/lib%{name}.so.%{so_ver}*
+
+
+%files devel
+%doc %dir %{_pkgdocdir}
+%doc %{_pkgdocdir}/ChangeLog
+%doc %{_pkgdocdir}/README*
+%{_includedir}/%{name}
+%{_libdir}/cmake/%{name}
+%{_libdir}/lib%{name}.so
+%{_libdir}/pkgconfig/%{name}.pc
+
+
+%files doc
+%if 0%{?fedora} || 0%{?rhel} >= 7
+%license %{_datadir}/licenses/%{name}*
+%endif
+%doc %{_pkgdocdir}
+
+
+%changelog
+* Tue Sep 14 2021 Tomas Korbar <tkorbar@redhat.com> - 0.14-11
+- Start providing versioned symbols
+- Resolves: rhbz#2001067
+
+* Mon Aug 09 2021 Mohan Boddu <mboddu@redhat.com> - 0.14-10
+- Rebuilt for IMA sigs, glibc 2.34, aarch64 flags
+  Related: rhbz#1991688
+
+* Fri Apr 16 2021 Mohan Boddu <mboddu@redhat.com> - 0.14-9
+- Rebuilt for RHEL 9 BETA on Apr 15th 2021. Related: rhbz#1947937
+
+* Tue Jan 26 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.14-8
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_34_Mass_Rebuild
+
+* Mon Jul 27 2020 Björn Esser <besser82@fedoraproject.org> - 0.14-7
+- Use new cmake macros
+
+* Tue May 26 2020 Björn Esser <besser82@fedoraproject.org> - 0.14-6
+- Build using Ninja instead of Make
+- Add a patch to move Doxyfile into doc subdir
+- Remove pre-built html documentation
+- Update Doxyfile during %%prep
+- Add a patch to apply some optimizations to arraylist
+- Hardlink the files in %%_pkgdocdir
+
+* Mon May 25 2020 Björn Esser <besser82@fedoraproject.org> - 0.14-5
+- Run the testssuite with valgrind on %%valgrind_arches
+
+* Mon May 18 2020 Björn Esser <besser82@fedoraproject.org> - 0.14-4
+- Add a patch to fix a test
+- Add a patch to fix generation of user-documentation
+
+* Mon May 11 2020 Björn Esser <besser82@fedoraproject.org> - 0.14-3
+- Add upstream patch fixing usage of errno in json_parse_uint64()
+
+* Sun May 10 2020 Björn Esser <besser82@fedoraproject.org> - 0.14-2
+- Add a patch to backport fixes applied on upstream master branch
+- Re-enable RDRAND as json-c can detect broken implementations in CPUs now
+- Disable -Werror during build
+
+* Tue Apr 21 2020 Björn Esser <besser82@fedoraproject.org> - 0.14-1
+- Update to 0.14
+
+* Mon Apr 20 2020 Björn Esser <besser82@fedoraproject.org> - 0.13.99-0.4.20200416gita911439
+- Remove config.h file from installation
+- Drop hardlinking of the documentation files
+
+* Thu Apr 16 2020 Björn Esser <besser82@fedoraproject.org> - 0.13.99-0.3.20200416gita911439
+- Update to recent git snapshot
+
+* Tue Apr 14 2020 Björn Esser <besser82@fedoraproject.org> - 0.13.99-0.2.20200414git7fb8d56
+- Update to recent git snapshot
+
+* Tue Apr 14 2020 Björn Esser <besser82@fedoraproject.org> - 0.13.99-0.1.20200414gitab5425a
+- Update to recent git snapshot using forge macros
+
+* Sun Apr 12 2020 Björn Esser <besser82@fedoraproject.org> - 0.13.1-11
+- Drop bootstrap logic, as the package is no dependency of @build anymore
+- Add some explicit BuildRequires, which were implicit
+- Small spec file cleanups
+
+* Sat Apr 11 2020 Björn Esser <besser82@fedoraproject.org> - 0.13.1-10
+- Add explicit configure switch to disable rdrand
+- Add explicit configure switch to enable linking with Bsymbolic
+- Do not use macros to invoke executables
+- Drop obsolete %%pretrans scriptlet
+
+* Wed Jan 29 2020 Fedora Release Engineering <releng@fedoraproject.org> - 0.13.1-9
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
+
+* Thu Nov 28 2019 Petr Menšík <pemensik@redhat.com> - 0.13.1-8
+- Remove empty doc dir from library package
+
+* Wed Nov 06 2019 Miroslav Lichvar <mlichvar@redhat.com> 0.13.1-7
+- Disable rdrand support (#1745333)
+
+* Thu Jul 25 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.13.1-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
+
+* Wed Jun 26 2019 Björn Esser <besser82@fedoraproject.org> - 0.13.1-5
+- Use hardlink without full path to the binary (#1721964)
+- Use new style bootstrap logic
+
+* Fri Feb 01 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.13.1-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_30_Mass_Rebuild
+
+* Fri Jul 13 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.13.1-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
+
+* Tue May 08 2018 Björn Esser <besser82@fedoraproject.org> - 0.13.1-2
+- Add some cherry-picked fixes from upstream master
+
+* Tue Mar 06 2018 Björn Esser <besser82@fedoraproject.org> - 0.13.1-1
+- New upstream release (rhbz#1552053)
+
+* Tue Mar 06 2018 Björn Esser <besser82@fedoraproject.org> - 0.13.1-0.1
+- Bootstrapping for so-name bump
+
+* Wed Feb 07 2018 Fedora Release Engineering <releng@fedoraproject.org> - 0.13-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild
+
+* Fri Feb 02 2018 Igor Gnatenko <ignatenkobrain@fedoraproject.org> - 0.13-6
+- Switch to %%ldconfig_scriptlets
+
+* Thu Dec 14 2017 Björn Esser <besser82@fedoraproject.org> - 0.13-5
+- Update patch fixing a segfault caused by possible invalid frees
+
+* Wed Dec 13 2017 Björn Esser <besser82@fedoraproject.org> - 0.13-4
+- Add upstream patch fixing invalid free in some cases
+
+* Wed Dec 13 2017 Björn Esser <besser82@fedoraproject.org> - 0.13-3
+- Add upstream patch for adding size_t json_c_object_sizeof()
+- Enable partial multi-threaded support
+
+* Mon Dec 11 2017 Björn Esser <besser82@fedoraproject.org> - 0.13-2
+- Drop json_object_private.h
+
+* Mon Dec 11 2017 Björn Esser <besser82@fedoraproject.org> - 0.13-1
+- New upstream release (rhbz#1524155)
+
+* Sun Dec 10 2017 Björn Esser <besser82@fedoraproject.org> - 0.13-0.1
+- Bootstrapping for so-name bump
+- Keep json_object_private.h
+
+* Thu Aug 03 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.12.1-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Binutils_Mass_Rebuild
+
+* Wed Jul 26 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.12.1-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
+
+* Mon Jul 03 2017 Björn Esser <besser82@fedoraproject.org> - 0.12.1-2
+- Add patch to replace obsolete autotools macro
+
+* Thu Apr 27 2017 Björn Esser <besser82@fedoraproject.org> - 0.12.1-1
+- Update to new upstream release
+- Introduces SONAME bump, that should have been in 0.12 already
+- Unify %%doc
+- General spec-file cleanup
+
+* Fri Feb 10 2017 Fedora Release Engineering <releng@fedoraproject.org> - 0.12-8
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
+
+* Thu Feb 04 2016 Fedora Release Engineering <releng@fedoraproject.org> - 0.12-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_24_Mass_Rebuild
+
+* Wed Jun 17 2015 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.12-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_23_Mass_Rebuild
+
+* Sat Aug 16 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.12-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_22_Mass_Rebuild
+
+* Tue Jul 29 2014 Christopher Meng <rpm@cicku.me> - 0.12-4
+- SONAME bump postponed.
+
+* Mon Jul 28 2014 Christopher Meng <rpm@cicku.me> - 0.12-3
+- SONAME bump, see bug 1123785
+
+* Fri Jul 25 2014 Christopher Meng <rpm@cicku.me> - 0.12-2
+- NVR bump
+
+* Thu Jul 24 2014 Christopher Meng <rpm@cicku.me> - 0.12-1
+- Update to 0.12
+
+* Sat Jul 12 2014 Tom Callaway <spot@fedoraproject.org> - 0.11-8
+- fix license handling
+
+* Sun Jun 08 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.11-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
+
+* Wed Apr 09 2014 Susi Lehtola <jussilehtola@fedoraproject.org> - 0.11-7
+- Address CVE-2013-6371 and CVE-2013-6370 (BZ #1085676 and #1085677).
+- Enabled rdrand support.
+
+* Mon Feb 10 2014 Susi Lehtola <jussilehtola@fedoraproject.org> - 0.11-6
+- Bump spec.
+
+* Sat Dec 21 2013 Ville Skyttä <ville.skytta@iki.fi> - 0.11-5
+- Run test suite during build.
+- Drop empty NEWS from docs.
+
+* Tue Sep 10 2013 Susi Lehtola <jussilehtola@fedoraproject.org> - 0.11-4
+- Remove default warning flags so that package builds on EPEL as well.
+
+* Sat Aug 24 2013 Remi Collet <remi@fedoraproject.org> - 0.11-3
+- increase parser strictness for php
+
+* Sat Aug 03 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.11-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
+
+* Mon Apr 29 2013 Remi Collet <remi@fedoraproject.org> - 0.11-1
+- update to 0.11
+- fix source0
+- enable both json and json-c libraries
+
+* Thu Feb 14 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.10-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Sat Nov 24 2012 Jussi Lehtola <jussilehtola@fedoraproject.org> - 0.10-2
+- Compile and install json_object_iterator using Remi Collet's fix (BZ #879771).
+
+* Sat Nov 24 2012 Jussi Lehtola <jussilehtola@fedoraproject.org> - 0.10-1
+- Update to 0.10 (BZ #879771).
+
+* Thu Jul 19 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.9-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Mon Jan 23 2012 Jiri Pirko <jpirko@redhat.com> - 0.9-4
+- add json_tokener_parse_verbose, and return NULL on parser errors
+
+* Fri Jan 13 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.9-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild
+
+* Wed Feb 09 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.9-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_15_Mass_Rebuild
+
+* Tue Apr 06 2010 Jussi Lehtola <jussilehtola@fedoraproject.org> - 0.9-1
+- First release.

--- a/SPECS/json-c.spec
+++ b/SPECS/json-c.spec
@@ -26,7 +26,7 @@
 
 Name:           json-c
 Version:        0.14
-Release:        11%{?dist}
+Release:        11.0.tee.1%{?dist}
 Summary:        JSON implementation in C
 
 License:        MIT
@@ -99,6 +99,7 @@ doxygen -s -u doc/Doxyfile.in
   -DDISABLE_WERROR:BOOL=ON           \
   -DENABLE_RDRAND:BOOL=ON            \
   -DENABLE_THREADING:BOOL=ON         \
+  -DCMAKE_C_STANDARD=99              \
   -G Ninja
 %cmake_build --target all doc
 
@@ -150,6 +151,10 @@ unset USE_VALGRIND
 
 
 %changelog
+* Mon Jan 20 2025 Thierry Escande <thierry.escande@vates.tech> - 0.14-11.1
+- Imported from json-c-0.14-11.el9.src.rpm
+- Set CMAKE_C_STANDARD=99
+
 * Tue Sep 14 2021 Tomas Korbar <tkorbar@redhat.com> - 0.14-11
 - Start providing versioned symbols
 - Resolves: rhbz#2001067


### PR DESCRIPTION
This is needed to build netdata v2.1.
Other packages that depend on json-c need to be rebuilt and tested:
- xen-dom0-tools
- xcp-emu-manager
- systemtap-runtime
- libreport-*
- libdmmp